### PR TITLE
fix: order labels and values the same way in execution metrics

### DIFF
--- a/rundeck_exporter.py
+++ b/rundeck_exporter.py
@@ -163,9 +163,9 @@ class RundeckMetricsCollector(object):
 
                     metrics.add_metric(
                         [
+                            project_name,
                             project_execution.get('job', {}).get('id', 'None'),
                             project_execution.get('job', {}).get('name', 'None'),
-                            project_name,
                             status
                         ],
                         value


### PR DESCRIPTION
The labels were ordered like this: `project_name, job_id, job_name, status` and the values like this: `job_id, job_name, project_name, status` - so the values were a little mixed up.