### PR TITLE
Handle errors when casting api version to integer

### DIFF
--- a/rundeck_exporter.py
+++ b/rundeck_exporter.py
@@ -375,7 +375,11 @@ class RundeckMetricsCollector(object):
         Rundeck system info
         """
         system_info = self.request_data_from('/system/info')
-        api_version = int(system_info['system']['rundeck']['apiversion'])
+        try:
+             api_version = int(system_info['system']['rundeck']['apiversion'])
+        except ValueError as err:
+              pass
+
         rundeck_system_info = InfoMetricFamily(
             name='rundeck_system',
             documentation='Rundeck system info',


### PR DESCRIPTION
To build on the previous PR #51 , also throw a ValueError if the api version request returns something unexpected in a future update