### PR TITLE
Update README with executions endpoints and ACL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This exporter uses the prometheus_client and requests Python module to expose Ru
 
  * RUNDECK_URL/*api_version*/system/info
  * RUNDECK_URL/*api_version*/metrics/metrics
+ * RUNDECK_URL/*api_version*/project/*project_name*/executions
+ * RUNDECK_URL/*api_version*/project/*project_name*/executions/running
 
  Where *version* represents the Rundeck API version, like: 31,32,33,34,etc.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Rundeck Metrics Exporter for Prometheus.
 
 This exporter uses the prometheus_client and requests Python module to expose Rundeck metrics found in:
 
- * RUNDECK_URL/*api_version*/system/info
- * RUNDECK_URL/*api_version*/metrics/metrics
- * RUNDECK_URL/*api_version*/project/*project_name*/executions
- * RUNDECK_URL/*api_version*/project/*project_name*/executions/running
+ * [RUNDECK_URL/*api_version*/system/info](https://docs.rundeck.com/docs/api/rundeck-api.html#system-info)
+ * [RUNDECK_URL/*api_version*/metrics/metrics](https://docs.rundeck.com/docs/api/rundeck-api.html#list-metrics)
+ * [RUNDECK_URL/*api_version*/project/*project_name*/executions](https://docs.rundeck.com/docs/api/rundeck-api.html#execution-query)
+ * [RUNDECK_URL/*api_version*/project/*project_name*/executions/running](https://docs.rundeck.com/docs/api/rundeck-api.html#listing-running-executions)
 
  Where *version* represents the Rundeck API version, like: 31,32,33,34,etc.
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,58 @@ More detailed information about the metrics can be found in [Documentations](doc
 pip install prometheus-client requests cachetools
 ```
 
-## Usage
+## API Authentication
 
 Rundeck token or username and password are required.
 
 The token (`RUNDECK_TOKEN`) or password (`RUNDECK_USERPASSWORD`) must be passed as environment variables to work.
+
+The ACL associated with the token/user must have the following policy rules as a minimum:
+* `system:read` (system context)
+* `project:read` (system context)
+* `events:read` (project context)
+
+Example ACL Policy allowing a user named "exporter" to get system metrics as well as execution metrics for any project:
+
+```yaml
+by:
+  username: exporter
+description: system:read
+for:
+  resource:
+  - allow:
+    - read
+    equals:
+      kind: system
+context:
+  application: rundeck
+---
+by:
+  username: exporter
+description: project:read
+for:
+  project:
+  - allow:
+    - read
+    match:
+      name: .*
+context:
+  application: rundeck
+---
+by:
+  username: exporter
+description: events:read
+for:
+  resource:
+  - allow:
+    - read
+    equals:
+      kind: event
+context:
+  project: .*
+```
+
+## Usage
 
 The rundeck_exporter supports the following paramenters:
 


### PR DESCRIPTION
Recently I was setting up a new API token following "principle of least privilege" so that the token's user would only be able to make the minimum API calls necessary to obtain metrics from the endpoints used by `rundeck_exporter`. The official API reference isn't consistent in explaining which policies are necessary for an endpoint, so this involved a lot of trial and error. I thought it might be helpful for other users to have an example of example which policy rules are necessary for `rundeck_exporter` to work.

This PR:
* updates the list of endpoints used by `rundeck_exporter` to include project execution endpoints, and turns each item in the bulleted list into a link to the API documentation for that endpoint
* adds a YAML example of minimum required ACL policies that can be copy/pasted into the Rundeck "Edit ACL Policy" `Editor` box.