### PR TITLE
remove recentFilter for /executions/running endpoint

### DIFF
--- a/rundeck_exporter.py
+++ b/rundeck_exporter.py
@@ -239,7 +239,7 @@ class RundeckMetricsCollector(object):
         project_executions_limit = self.args.rundeck_projects_executions_limit
         project_executions_filter = self.args.rundeck_project_executions_filter
         endpoint = f'/project/{project_name}/executions?recentFilter={project_executions_filter}&max={project_executions_limit}'
-        endpoint_running_executions = f'/project/{project_name}/executions/running?recentFilter={project_executions_filter}&max={project_executions_limit}'
+        endpoint_running_executions = f'/project/{project_name}/executions/running?max={project_executions_limit}'
 
         try:
             if self.args.rundeck_projects_executions_cache:

--- a/rundeck_exporter.py
+++ b/rundeck_exporter.py
@@ -239,7 +239,7 @@ class RundeckMetricsCollector(object):
         project_executions_limit = self.args.rundeck_projects_executions_limit
         project_executions_filter = self.args.rundeck_project_executions_filter
         endpoint = f'/project/{project_name}/executions?recentFilter={project_executions_filter}&max={project_executions_limit}'
-        endpoint_running_executions = f'/project/{project_name}/executions/running?recentFilter=1d&max={project_executions_limit}'
+        endpoint_running_executions = f'/project/{project_name}/executions/running?recentFilter={project_executions_filter}&max={project_executions_limit}'
 
         try:
             if self.args.rundeck_projects_executions_cache:


### PR DESCRIPTION
~#69 introduced made the execution API's `recentFilter` value configurable via `RUNDECK_PROJECTS_EXECUTIONS_FILTER` but this was only applied to the main `/executions` endpoint. This PR also uses the value in the `/executions/running` endpoint.~

We discovered the endpoint doesn't accept this parameter, so we're now just removing it altogether.