### PR TITLE
Add option for external secrets in helm chart

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
   name: Natália Granato
 name: rundeck-exporter
 type: application
-version: 0.1.8
+version: 0.2.0

--- a/charts/README.md
+++ b/charts/README.md
@@ -14,25 +14,25 @@ Rundeck Exporter was developed by Phillipe Smith and is part of the Rundeck comm
 
 ## Installation
 
-1.Clone the repository
+1. Clone the repository
 
 ```
-git clone https://github.com/nataliagranato/rundeck_exporter.git
+git clone https://github.com/phsmith/rundeck_exporter.git
 ```
 
-2.Access the charts directory
+2. Access the charts directory
 
 ```
 cd charts 
 ```
 
-3.Create namespace (if no):
+3. Create namespace (if no):
 
 ```
 kubectl create namespace my-namespace
 ```
 
-4.Install the Rundeck Exporter:
+4. Install the Rundeck Exporter:
 
 ```
 helm install rundeck-exporter -n your-namespace .
@@ -44,17 +44,17 @@ The Rundeck Exporter configuration can be customized by editing the values.yaml 
 
 Here are some common settings:
 
-'image.repository': The Rundeck Exporter image repository.
-'image.tag': The tag of the Rundeck Exporter image.
-'replicaCount': The number of replicas desired for Rundeck Exporter.
-'service.port': The port on which Rundeck Exporter exposes metrics.
-'env': Environment variables to configure Rundeck Exporter.
+- `image.repository`: The Rundeck Exporter image repository.
+- `image.tag`: The tag of the Rundeck Exporter image.
+- `replicaCount`: The number of replicas desired for Rundeck Exporter.
+- `service.port`: The port on which Rundeck Exporter exposes metrics.
+- `env`: Environment variables to configure Rundeck Exporter.
 
-See the values.yaml file for all available configuration options.
+See the `values.yaml` file for all available configuration options.
 
 ## Customization
 
-You can further customize the Rundeck Exporter deployment by editing the deployment.yaml file in the templates directory. Here you can add volumes, define resources, configure readiness and vitality probes, among other options.
+You can further customize the Rundeck Exporter deployment by editing the `deployment.yaml` file in the templates directory. Here you can add volumes, define resources, configure readiness and vitality probes, among other options.
 
 ## Removal
 

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -19,33 +19,18 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           ports:
             - containerPort: {{ .Values.service.port }}
+          {{- if .Values.envSecret }}
+          envFrom:
+          - secretRef:
+              name: {{ .Values.envSecret }}
+          {{- end }}
+          {{- if .Values.env }}
           env:
-            - name: RUNDECK_EXPORTER_DEBUG
-              value: "{{ .Values.env.RUNDECK_EXPORTER_DEBUG }}"
-            - name: RUNDECK_EXPORTER_HOST
-              value: "{{ .Values.env.RUNDECK_EXPORTER_HOST }}"
-            - name: RUNDECK_EXPORTER_PORT
-              value: "{{ .Values.env.RUNDECK_EXPORTER_PORT }}"
-            - name: RUNDECK_TOKEN
-              value: "{{ .Values.env.RUNDECK_TOKEN }}"
-            - name: RUNDECK_URL
-              value: "{{ .Values.env.RUNDECK_URL }}"
-            - name: RUNDECK_USERNAME
-              value: "{{ .Values.env.RUNDECK_USERNAME }}"
-            - name: RUNDECK_USERPASSWORD
-              value: "{{ .Values.env.RUNDECK_USERPASSWORD }}"
-            - name: RUNDECK_API_VERSION
-              value: "{{ .Values.env.RUNDECK_API_VERSION }}"
-            - name: RUNDECK_SKIP_SSL
-              value: "{{ .Values.env.RUNDECK_SKIP_SSL }}"
-            - name: RUNDECK_PROJECTS_EXECUTIONS
-              value: "{{ .Values.env.RUNDECK_PROJECTS_EXECUTIONS }}"
-            - name: RUNDECK_PROJECTS_EXECUTIONS_CACHE
-              value: "{{ .Values.env.RUNDECK_PROJECTS_EXECUTIONS_CACHE }}"
-            - name: RUNDECK_CPU_STATS
-              value: "{{ .Values.env.RUNDECK_CPU_STATS }}"
-            - name: RUNDECK_MEMORY_STATS
-              value: "{{ .Values.env.RUNDECK_MEMORY_STATS }}"   
+            {{- range $key, $value := .Values.env }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+            {{- end }}
+          {{- end }}
           {{- include "rundeck-exporter.volumeMounts" . | nindent 6 }}
       {{- include "rundeck-exporter.volumes" . | nindent 6 }}
       {{- if not .Values.probe.disabled }}

--- a/charts/templates/extra-manifests.yaml
+++ b/charts/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -3,7 +3,6 @@ replicaCount: 1
 image:
   repository: phsmith/rundeck-exporter
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: 2.6.1
 
 env:
@@ -20,6 +19,9 @@ env:
   RUNDECK_PROJECTS_EXECUTIONS_CACHE: true
   RUNDECK_CPU_STATS: true
   RUNDECK_MEMORY_STATS: true
+
+# Specifies a secret to load environment variables from (e.g. RUNDECK_TOKEN)
+envSecret: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -90,3 +92,20 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Create a dynamic manifests via values:
+extraObjects: []
+  # - apiVersion: external-secrets.io/v1beta1
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: rundeck-exporter-token
+  #   spec:
+  #     refreshInterval: 1h
+  #     secretStoreRef:
+  #       kind: ClusterSecretStore
+  #       name: gcp-store
+  #     target:
+  #       name: rundeck-exporter-token
+  #     dataFrom:
+  #     - extract:
+  #         key: rundeck-exporter-token


### PR DESCRIPTION
This extends the chart with a custom configurable list of additional resources to make the use of external secrets operators easy.

Such a secret can then be referenced via `envSecret` to load environment variables from the secret into the container runtime environment to not have to maintain the rundeck token or user/password combination in plaintext configuration.

Also did some styling changes in the `README` as it was looking a bit wonky in the GitHub preview