### PR TITLE
Extend exporter ACL policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ for:
     - read
     equals:
       kind: event
+  job:
+  - allow:
+    - read
+    - view
 context:
   project: .*
 ```


### PR DESCRIPTION
This allows the exporter to view details about a job which is relevant for the content of the `project/.../executions` endpoint. 

Without this permission the response never contains details about executions so all the exporter knows about is running executions but not what happened with the executions which makes it a bit pointless.

I was using the policy that was added via https://github.com/phsmith/rundeck_exporter/pull/67 but all the dashboard showed for me was 0% success rate and every job was supposedly in running state. Turns out the exporter did not have permissions to get information about the executions once they were out of running. Maybe this is a new part of the ACLs, not sure. I am on rundeck 4.17