### PR TITLE
Add new arg --no_checks_in_passive_mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.4] - 2024-03-05
+### Added
+- Issue [#83](https://github.com/phsmith/rundeck_exporter/issues/83), added new `--no_checks_in_passive_mode` argument and `RUNDECK_EXPORTER_NO_CHECKS_IN_PASSIVE_MODE=<False|True>` env var introduced to keep the rundeck_exporter idle while the Rundeck host is in `passive` execution mode.
+
 ## [2.6.3] - 2023-11-10
 ### Added
 - Added Helm Chart by @nataliagranato in https://github.com/phsmith/rundeck_exporter/pull/76
@@ -207,7 +211,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2020-08-12
 ### Added
-- Added param --rundeck.projects.executions.cache and env RUNDECK_PROJECTS_EXECUTIONS_CACHE
+- Added argument `--rundeck.projects.executions.cache` and  `RUNDECK_PROJECTS_EXECUTIONS_CACHE` env var
 - Added counter metrics rundeck_services_[services,controllers,api,web]_total
 
 ### Changed
@@ -216,8 +220,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Removed all gauge metrics rundeck_[services,controllers,api,web]...{type="..."}
 - Removed metrics rundeck_system_stats_[cpu,memory,uptime_duration]...
-- Removed param --rundeck.token. Need RUNDECK_TOKEN env now.
-- Removed param --rundeck.projects.executions.limit
+- Removed argument `--rundeck.token`. Need `RUNDECK_TOKEN` env now.
+- Removed argument `--rundeck.projects.executions.limit`
 - Removed rundeck_node label from all metrics
 
 ### Fixed
@@ -225,12 +229,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.0] - 2020-08-06
 ### Added
-- Added new params:
-  * --debug: Enable debug mode
-  * --rundeck.projects.executions: Get projects executions metrics
-  * --rundeck.projects.filter: Get executions only from listed projects (delimiter = space)
-  * --rundeck.projects.executions.limit: Limit project executions metrics query. Default: 20
-  * --rundeck.cached.requests.ttl: Rundeck cached requests (by now, only for rundeck.projects.executions) expiration time. Default: 120
+- Added new argument:
+  * `--debug`: Enable debug mode
+  * `--rundeck.projects.executions`: Get projects executions metrics
+  * `--rundeck.projects.filter`: Get executions only from listed projects (delimiter = space)
+  * `--rundeck.projects.executions.limit`: Limit project executions metrics query. Default: 20
+  * `--rundeck.cached.requests.ttl`: Rundeck cached requests (by now, only for rundeck.projects.executions) expiration time. Default: 120
 - Added code improvements
 - Added cachetools to pip install on Dockerfile
 - Added logging module to replace print calls
@@ -254,7 +258,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[unreleased]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.3...HEAD
+[unreleased]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.4...HEAD
+[2.6.4]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.0...v2.6.1

--- a/README.md
+++ b/README.md
@@ -35,9 +35,16 @@ More detailed information about the metrics can be found in [Documentations](doc
 
 * A Rundeck token with permissions to make API requests
 * The following python modules:
-```
-pip install prometheus-client requests cachetools
-```
+
+  ```sh
+  pip install prometheus-client requests cachetools
+  ```
+
+  Or:
+
+  ```sh
+  pip install -r requirements.txt
+  ```
 
 ## API Authentication
 
@@ -98,12 +105,12 @@ context:
 
 The rundeck_exporter supports the following paramenters:
 
-```
+```text
 $ ./rundeck_exporter.py --help
 
-usage: rundeck_exporter.py [-h] [--debug] [-v] [--host RUNDECK_EXPORTER_HOST] [--port RUNDECK_EXPORTER_PORT] [--rundeck.url RUNDECK_URL] [--rundeck.skip_ssl] [--rundeck.api.version RUNDECK_API_VERSION] [--rundeck.username RUNDECK_USERNAME] [--rundeck.projects.executions]
-                           [--rundeck.projects.executions.filter RUNDECK_PROJECT_EXECUTIONS_FILTER] [--rundeck.projects.executions.limit RUNDECK_PROJECTS_EXECUTIONS_LIMIT] [--rundeck.projects.executions.cache]
-                           [--rundeck.projects.filter RUNDECK_PROJECTS_FILTER [RUNDECK_PROJECTS_FILTER ...]] [--rundeck.cached.requests.ttl RUNDECK_CACHED_REQUESTS_TTL] [--rundeck.cpu.stats] [--rundeck.memory.stats]
+usage: rundeck_exporter.py [-h] [--debug] [-v] [--host RUNDECK_EXPORTER_HOST] [--port RUNDECK_EXPORTER_PORT] [--no_checks_in_passive_mode] [--rundeck.url RUNDECK_URL] [--rundeck.skip_ssl] [--rundeck.api.version RUNDECK_API_VERSION] [--rundeck.username RUNDECK_USERNAME] [--rundeck.projects.executions]
+                           [--rundeck.projects.executions.filter RUNDECK_PROJECT_EXECUTIONS_FILTER] [--rundeck.projects.executions.limit RUNDECK_PROJECTS_EXECUTIONS_LIMIT] [--rundeck.projects.executions.cache] [--rundeck.projects.filter RUNDECK_PROJECTS_FILTER [RUNDECK_PROJECTS_FILTER ...]] [--rundeck.cached.requests.ttl RUNDECK_CACHED_REQUESTS_TTL]
+                           [--rundeck.cpu.stats] [--rundeck.memory.stats]
 
 Rundeck Metrics Exporter
 
@@ -119,6 +126,8 @@ options:
                         Host binding address. Default: 127.0.0.1.
   --port RUNDECK_EXPORTER_PORT
                         Host binding port. Default: 9620.
+  --no_checks_in_passive_mode
+                        The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode.
   --rundeck.url RUNDECK_URL
                         Rundeck Base URL [ REQUIRED ].
   --rundeck.skip_ssl    Rundeck Skip SSL Cert Validate.
@@ -129,7 +138,7 @@ options:
   --rundeck.projects.executions
                         Get projects executions metrics.
   --rundeck.projects.executions.filter RUNDECK_PROJECT_EXECUTIONS_FILTER
-                        Project executions filter by a period of time. Can be in: [s]: seconds, [n]: minutes, [h]: hour, [d]: day, [w]: week, [m]: month, [y]: year. Default: 5n.
+                        Get the latest project executions filtered by time period. Can be in: [s]: seconds, [n]: minutes, [h]: hour, [d]: day, [w]: week, [m]: month, [y]: year. Default: 5n.
   --rundeck.projects.executions.limit RUNDECK_PROJECTS_EXECUTIONS_LIMIT
                         Project executions max results per query. Default: 20.
   --rundeck.projects.executions.cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cachetools==4.2.2
-prometheus-client==0.11.0
+cachetools==5.3.3
+prometheus-client==0.20.0
 requests==2.31.0


### PR DESCRIPTION
Issue #83: Added new `--no_checks_in_passive_mode` argument and `RUNDECK_EXPORTER_NO_CHECKS_IN_PASSIVE_MODE=<False|True>` env var introduced to keep the rundeck_exporter idle while the Rundeck host is in `passive` execution mode.