### PR TITLE
Release v2.7.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,8 +64,11 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
+          # Push docker image:latest if no alfa or beta is set in the version tag.
+          if [[ ! "$VERSION" =~ (alfa|beta) ]]; then
+            docker tag $IMAGE_NAME $IMAGE_ID:latest
+            docker push $IMAGE_ID:latest
+          fi
 
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
@@ -85,10 +88,14 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
+          # Push docker image:latest if no alfa or beta is set in the version tag.
+          if [[ ! "$VERSION" =~ (alfa|beta) ]]; then
+            docker tag $IMAGE_NAME $IMAGE_ID:latest
+            docker push $IMAGE_ID:latest
+          fi
+
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:latest
           docker push $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `--rundeck.requests.timeout` - The maximum number of seconds that requests to the Rundeck API should timeout.
     - Defaults to 30.
 
-## Changed
+### Changed
 - Changed the functions `request_data_from` and `cached_request_data_from` to `request` and `cached_request` respectivelly.
 
 ## [2.6.5] - 2024-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.7.0] - 2024-04-02
+## [2.7.0] - 2024-04-20
 ### Added
-- Issue [#87](https://github.com/phsmith/rundeck_exporter/issues/87), the following new arguments have been added to try to reduce the CPU load:
+- Added the following new arguments:
   - `--rundeck.projects.nodes.info` - If passed, display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available.
-    - This check can cause a high CPU load depending on the number of projects.
+    - Requests for this check are cached as it can cause high CPU load depending on the number of projects.
   - `--threadpool_max_workers` - The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks.
     - Defaults to `(number of CPUs) + 4`, which may be too much on a server running other services.
   - `--rundeck.requests.timeout` - The maximum number of seconds that requests to the Rundeck API should timeout.
     - Defaults to 30.
+
+## Changed
+- Changed the functions `request_data_from` and `cached_request_data_from` to `request` and `cached_request` respectivelly.
 
 ## [2.6.5] - 2024-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Defaults to 30.
 
 ### Changed
-- Changed the functions `request_data_from` and `cached_request_data_from` to `request` and `cached_request` respectivelly.
+- Changed the functions `request_data_from` and `cached_request_data_from` to `request` and `cached_request`, respectively.
 
 ## [2.6.5] - 2024-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.7.0] - 2024-03-28
+## [2.7.0] - 2024-04-02
 ### Added
 - Issue [#87](https://github.com/phsmith/rundeck_exporter/issues/87), the following new arguments have been added to try to reduce the CPU load:
   - `--rundeck.projects.nodes.info` - If passed, display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available.
     - This check can cause a high CPU load depending on the number of projects.
   - `--threadpool_max_workers` - The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks.
     - Defaults to `(number of CPUs) + 4`, which may be too much on a server running other services.
+  - `--rundeck.requests.timeout` - The maximum number of seconds that requests to the Rundeck API should timeout.
+    - Defaults to 30.
 
 ## [2.6.5] - 2024-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.6.5] - 2024-03-011
+## [2.7.0] - 2024-03-28
+### Added
+- Issue [#87](https://github.com/phsmith/rundeck_exporter/issues/87), the following new arguments have been added to try to reduce the CPU load:
+  - `--rundeck.projects.nodes.info` - If passed, display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available.
+    - This check can cause a high CPU load depending on the number of projects.
+  - `--threadpool_max_workers` - The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks.
+    - Defaults to `(number of CPUs) + 4`, which may be too much on a server running other services.
+
+## [2.6.5] - 2024-03-11
 ### Added
 - Issue [#85](https://github.com/phsmith/rundeck_exporter/issues/85), added new metric `rundeck_project_nodes_total`.
 
@@ -262,7 +270,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[unreleased]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.5...HEAD
+[unreleased]: https://github.com/phsmith/rundeck_exporter/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.5...v2.7.0
 [2.6.5]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.4...v2.6.5
 [2.6.4]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/phsmith/rundeck_exporter/compare/v2.6.2...v2.6.3

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ The rundeck_exporter supports the following paramenters:
 ```text
 $ ./rundeck_exporter.py --help
 
-usage: rundeck_exporter.py [-h] [--debug] [-v] [--host RUNDECK_EXPORTER_HOST] [--port RUNDECK_EXPORTER_PORT] [--no_checks_in_passive_mode] [--threadpool_max_workers RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS] [--rundeck.url RUNDECK_URL] [--rundeck.skip_ssl] [--rundeck.api.version RUNDECK_API_VERSION] [--rundeck.username RUNDECK_USERNAME]
-                           [--rundeck.projects.executions] [--rundeck.projects.executions.filter RUNDECK_PROJECT_EXECUTIONS_FILTER] [--rundeck.projects.executions.limit RUNDECK_PROJECTS_EXECUTIONS_LIMIT] [--rundeck.projects.executions.cache] [--rundeck.projects.filter RUNDECK_PROJECTS_FILTER [RUNDECK_PROJECTS_FILTER ...]] [--rundeck.projects.nodes.info]
-                           [--rundeck.cached.requests.ttl RUNDECK_CACHED_REQUESTS_TTL] [--rundeck.cpu.stats] [--rundeck.memory.stats]
+usage: rundeck_exporter.py [-h] [--debug] [-v] [--host RUNDECK_EXPORTER_HOST] [--port RUNDECK_EXPORTER_PORT] [--no_checks_in_passive_mode] [--threadpool_max_workers RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS] [--rundeck.requests.timeout RUNDECK_EXPORTER_REQUESTS_TIMEOUT] [--rundeck.url RUNDECK_URL] [--rundeck.skip_ssl] [--rundeck.api.version RUNDECK_API_VERSION]
+                           [--rundeck.username RUNDECK_USERNAME] [--rundeck.projects.executions] [--rundeck.projects.executions.filter RUNDECK_PROJECT_EXECUTIONS_FILTER] [--rundeck.projects.executions.limit RUNDECK_PROJECTS_EXECUTIONS_LIMIT] [--rundeck.projects.executions.cache] [--rundeck.projects.filter RUNDECK_PROJECTS_FILTER [RUNDECK_PROJECTS_FILTER ...]]
+                           [--rundeck.projects.nodes.info] [--rundeck.cached.requests.ttl RUNDECK_CACHED_REQUESTS_TTL] [--rundeck.cpu.stats] [--rundeck.memory.stats]
 
 Rundeck Metrics Exporter
 
@@ -145,67 +145,70 @@ required environment vars:
     RUNDECK_USERPASSWORD Rundeck User Password (RUNDECK_USERNAME or --rundeck.username are required too)
 
 options:
-  -h, --help            show this help message and exit.
-  --debug               Enable debug mode.
-  -v, --version         Shows rundeck_exporter current release version.
+  -h, --help            show this help message and exit
+  --debug               Enable debug mode
+  -v, --version         Shows rundeck_exporter current release version
   --host RUNDECK_EXPORTER_HOST
-                        Host binding address. Default: 127.0.0.1.
+                        Host binding address. Default: 127.0.0.1
   --port RUNDECK_EXPORTER_PORT
-                        Host binding port. Default: 9620.
+                        Host binding port. Default: 9620
   --no_checks_in_passive_mode
-                        The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode.
+                        The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode
   --threadpool_max_workers RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS
-                        The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks. Defaults to (number of CPUs) + 4.
+                        The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks. Defaults to (number of CPUs) + 4
+  --rundeck.requests.timeout RUNDECK_EXPORTER_REQUESTS_TIMEOUT
+                        The maximum number of seconds that requests to the Rundeck API should timeout
   --rundeck.url RUNDECK_URL
-                        Rundeck Base URL [ REQUIRED ].
-  --rundeck.skip_ssl    Rundeck Skip SSL Cert Validate.
+                        Rundeck Base URL [ REQUIRED ]
+  --rundeck.skip_ssl    Rundeck Skip SSL Cert Validate
   --rundeck.api.version RUNDECK_API_VERSION
-                        Default: 34.
+                        Defaults to 34
   --rundeck.username RUNDECK_USERNAME
-                        Rundeck User with access to the system information.
+                        Rundeck User with access to the system information
   --rundeck.projects.executions
-                        Get projects executions metrics.
+                        Get projects executions metrics
   --rundeck.projects.executions.filter RUNDECK_PROJECT_EXECUTIONS_FILTER
-                        Get the latest project executions filtered by time period. Can be in: [s]: seconds, [n]: minutes, [h]: hour, [d]: day, [w]: week, [m]: month, [y]: year. Default: 5n.
+                        Get the latest project executions filtered by time period Can be in: [s]: seconds, [n]: minutes, [h]: hour, [d]: day, [w]: week, [m]: month, [y]: year Defaults to 5n
   --rundeck.projects.executions.limit RUNDECK_PROJECTS_EXECUTIONS_LIMIT
-                        Project executions max results per query. Default: 20.
+                        Project executions max results per query. Defaults to 20
   --rundeck.projects.executions.cache
-                        Cache requests for project executions metrics query.
+                        Cache requests for project executions metrics query
   --rundeck.projects.filter RUNDECK_PROJECTS_FILTER [RUNDECK_PROJECTS_FILTER ...]
-                        Get executions only from listed projects (delimiter = space).
+                        Get executions only from listed projects (delimiter = space)
   --rundeck.projects.nodes.info
-                        Display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available. May cause high CPU load depending on the number of projects.
+                        Display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available. May cause high CPU load depending on the number of projects
   --rundeck.cached.requests.ttl RUNDECK_CACHED_REQUESTS_TTL
-                        Rundeck cached requests expiration time. Default: 120.
-  --rundeck.cpu.stats   Show Rundeck CPU usage stats.
+                        Rundeck cached requests expiration time. Defaults to 120
+  --rundeck.cpu.stats   Show Rundeck CPU usage stats
   --rundeck.memory.stats
-                        Show Rundeck memory usage stats.
+                        Show Rundeck memory usage stats
 ```
 
 Optionally, it's possible to pass the following environment variables to the rundeck_exporter:
 
 | Variable | Options |  Description |
 | ------ | ------ | ------ |
-| RUNDECK_EXPORTER_DEBUG | <ul><li>True</li><li>False (default)</li></ul> | Enable debug mode. |
-| RUNDECK_EXPORTER_HOST | Default: 127.0.0.1 | Binding address. |
-| RUNDECK_EXPORTER_PORT | Default: 9620 | Binding port. |
-| RUNDECK_URL (required) | | Rundeck base URL. |
-| RUNDECK_TOKEN (required) | | Rundeck access token. |
-| RUNDECK_USERNAME | | Rundeck User with access to the system information. |
-| RUNDECK_USERPASSWORD | | Rundeck User Password (RUNDECK_USERNAME or --rundeck.username are required too). |
-| RUNDECK_API_VERSION | Default: 31 | Rundeck API version. |
-| RUNDECK_SKIP_SSL | <ul><li>True</li><li>False (default)</li></ul> | Skip SSL certificate check. |
-| RUNDECK_PROJECTS_EXECUTIONS | <ul><li>True</li><li>False (default)</li></ul> | Get projects executions metrics. |
+| RUNDECK_EXPORTER_DEBUG | <ul><li>True</li><li>False (default)</li></ul> | Enable debug mode |
+| RUNDECK_EXPORTER_HOST | Default: 127.0.0.1 | Binding address |
+| RUNDECK_EXPORTER_PORT | Default: 9620 | Binding port |
+| RUNDECK_URL (required) | | Rundeck base URL |
+| RUNDECK_TOKEN (required) | | Rundeck access token |
+| RUNDECK_USERNAME | | Rundeck User with access to the system information |
+| RUNDECK_USERPASSWORD | | Rundeck User Password (RUNDECK_USERNAME or --rundeck.username are required too) |
+| RUNDECK_API_VERSION | Default: 31 | Rundeck API version |
+| RUNDECK_SKIP_SSL | <ul><li>True</li><li>False (default)</li></ul> | Skip SSL certificate check |
+| RUNDECK_PROJECTS_EXECUTIONS | <ul><li>True</li><li>False (default)</li></ul> | Get projects executions metrics |
 | RUNDECK_PROJECTS_FILTER | | Get executions only from listed projects e.g. "project-1 project-2 ..." |
-| RUNDECK_PROJECT_EXECUTIONS_FILTER | Default: 5n | Project executions filter by a period of time. Can be in: **[s]**: seconds, **[n]**: minutes, **[h]**: hour, **[d]**: day, **[w]**: week, **[m]**: month, **[y]**: year. |
+| RUNDECK_PROJECT_EXECUTIONS_FILTER | Default: 5n | Project executions filter by a period of time. Can be in: **[s]**: seconds, **[n]**: minutes, **[h]**: hour, **[d]**: day, **[w]**: week, **[m]**: month, **[y]**: year |
 | RUNDECK_PROJECTS_EXECUTIONS_LIMIT | Default: 20 | Projects executions max results per query |
-| RUNDECK_PROJECTS_EXECUTIONS_CACHE | <ul><li>True</li><li>False (default)</li></ul> | Cache requests for project executions metrics query. |
-| RUNDECK_PROJECTS_NODES_INFO | <ul><li>True</li><li>False (default)</li></ul> | Display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available. May cause high CPU load depending on the number of projects. |
-| RUNDECK_CACHED_REQUESTS_TTL | Default: 120 | Rundeck cached requests expiration time. |
-| RUNDECK_CPU_STATS | <ul><li>True</li><li>False (default)</li></ul> | Show Rundeck CPU usage stats. |
-| RUNDECK_MEMORY_STATS | <ul><li>True</li><li>False (default)</li></ul> | Show Rundeck memory usage stats. |
-| RUNDECK_EXPORTER_NO_CHECKS_IN_PASSIVE_MODE | <ul><li>True</li><li>False (default)</li></ul> | The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode. |
-| RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS |Default: (number of CPUs) + 4 | The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks. |
+| RUNDECK_PROJECTS_EXECUTIONS_CACHE | <ul><li>True</li><li>False (default)</li></ul> | Cache requests for project executions metrics query |
+| RUNDECK_PROJECTS_NODES_INFO | <ul><li>True</li><li>False (default)</li></ul> | Display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available. May cause high CPU load depending on the number of projects |
+| RUNDECK_CACHED_REQUESTS_TTL | Default: 120 | Rundeck cached requests expiration time |
+| RUNDECK_CPU_STATS | <ul><li>True</li><li>False (default)</li></ul> | Show Rundeck CPU usage stats |
+| RUNDECK_MEMORY_STATS | <ul><li>True</li><li>False (default)</li></ul> | Show Rundeck memory usage stats |
+| RUNDECK_EXPORTER_NO_CHECKS_IN_PASSIVE_MODE | <ul><li>True</li><li>False (default)</li></ul> | The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode |
+| RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS | Default: (number of CPUs) + 4 | The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks |
+| RUNDECK_EXPORTER_REQUESTS_TIMEOUT | Default: 30 | The maximum number of seconds that requests to the Rundeck API should timeout |
 
 ### Example
 
@@ -218,7 +221,8 @@ $ RUNDECK_TOKEN=xxxxxxxx ./rundeck_exporter.py \
     --rundeck.memory.stats \
     --rundeck.projects.filter="project-1 project-2 project-n" \
     --rundeck.projects.executions \
-    --rundeck.projects.executions.filter=5n
+    --rundeck.projects.executions.filter=5n \
+    --rundeck.requests.timeout=10
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ The rundeck_exporter supports the following paramenters:
 ```text
 $ ./rundeck_exporter.py --help
 
-usage: rundeck_exporter.py [-h] [--debug] [-v] [--host RUNDECK_EXPORTER_HOST] [--port RUNDECK_EXPORTER_PORT] [--no_checks_in_passive_mode] [--rundeck.url RUNDECK_URL] [--rundeck.skip_ssl] [--rundeck.api.version RUNDECK_API_VERSION] [--rundeck.username RUNDECK_USERNAME] [--rundeck.projects.executions]
-                           [--rundeck.projects.executions.filter RUNDECK_PROJECT_EXECUTIONS_FILTER] [--rundeck.projects.executions.limit RUNDECK_PROJECTS_EXECUTIONS_LIMIT] [--rundeck.projects.executions.cache] [--rundeck.projects.filter RUNDECK_PROJECTS_FILTER [RUNDECK_PROJECTS_FILTER ...]] [--rundeck.cached.requests.ttl RUNDECK_CACHED_REQUESTS_TTL]
-                           [--rundeck.cpu.stats] [--rundeck.memory.stats]
+usage: rundeck_exporter.py [-h] [--debug] [-v] [--host RUNDECK_EXPORTER_HOST] [--port RUNDECK_EXPORTER_PORT] [--no_checks_in_passive_mode] [--threadpool_max_workers RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS] [--rundeck.url RUNDECK_URL] [--rundeck.skip_ssl] [--rundeck.api.version RUNDECK_API_VERSION] [--rundeck.username RUNDECK_USERNAME]
+                           [--rundeck.projects.executions] [--rundeck.projects.executions.filter RUNDECK_PROJECT_EXECUTIONS_FILTER] [--rundeck.projects.executions.limit RUNDECK_PROJECTS_EXECUTIONS_LIMIT] [--rundeck.projects.executions.cache] [--rundeck.projects.filter RUNDECK_PROJECTS_FILTER [RUNDECK_PROJECTS_FILTER ...]] [--rundeck.projects.nodes.info]
+                           [--rundeck.cached.requests.ttl RUNDECK_CACHED_REQUESTS_TTL] [--rundeck.cpu.stats] [--rundeck.memory.stats]
 
 Rundeck Metrics Exporter
 
@@ -145,7 +145,7 @@ required environment vars:
     RUNDECK_USERPASSWORD Rundeck User Password (RUNDECK_USERNAME or --rundeck.username are required too)
 
 options:
-  -h, --help            show this help message and exit
+  -h, --help            show this help message and exit.
   --debug               Enable debug mode.
   -v, --version         Shows rundeck_exporter current release version.
   --host RUNDECK_EXPORTER_HOST
@@ -154,6 +154,8 @@ options:
                         Host binding port. Default: 9620.
   --no_checks_in_passive_mode
                         The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode.
+  --threadpool_max_workers RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS
+                        The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks. Defaults to (number of CPUs) + 4.
   --rundeck.url RUNDECK_URL
                         Rundeck Base URL [ REQUIRED ].
   --rundeck.skip_ssl    Rundeck Skip SSL Cert Validate.
@@ -171,24 +173,26 @@ options:
                         Cache requests for project executions metrics query.
   --rundeck.projects.filter RUNDECK_PROJECTS_FILTER [RUNDECK_PROJECTS_FILTER ...]
                         Get executions only from listed projects (delimiter = space).
+  --rundeck.projects.nodes.info
+                        Display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available. May cause high CPU load depending on the number of projects.
   --rundeck.cached.requests.ttl RUNDECK_CACHED_REQUESTS_TTL
-                        Rundeck cached requests expiration time. Default: 120
-  --rundeck.cpu.stats   Show Rundeck CPU usage stats
+                        Rundeck cached requests expiration time. Default: 120.
+  --rundeck.cpu.stats   Show Rundeck CPU usage stats.
   --rundeck.memory.stats
-                        Show Rundeck memory usage stats
+                        Show Rundeck memory usage stats.
 ```
 
 Optionally, it's possible to pass the following environment variables to the rundeck_exporter:
 
 | Variable | Options |  Description |
 | ------ | ------ | ------ |
-| RUNDECK_EXPORTER_DEBUG | <ul><li>True</li><li>False (default)</li></ul> | Enable debug mode |
+| RUNDECK_EXPORTER_DEBUG | <ul><li>True</li><li>False (default)</li></ul> | Enable debug mode. |
 | RUNDECK_EXPORTER_HOST | Default: 127.0.0.1 | Binding address. |
 | RUNDECK_EXPORTER_PORT | Default: 9620 | Binding port. |
-| RUNDECK_URL (required) | | Rundeck base URL |
-| RUNDECK_TOKEN (required) | | Rundeck access token |
-| RUNDECK_USERNAME | | Rundeck User with access to the system information |
-| RUNDECK_USERPASSWORD | | Rundeck User Password (RUNDECK_USERNAME or --rundeck.username are required too) |
+| RUNDECK_URL (required) | | Rundeck base URL. |
+| RUNDECK_TOKEN (required) | | Rundeck access token. |
+| RUNDECK_USERNAME | | Rundeck User with access to the system information. |
+| RUNDECK_USERPASSWORD | | Rundeck User Password (RUNDECK_USERNAME or --rundeck.username are required too). |
 | RUNDECK_API_VERSION | Default: 31 | Rundeck API version. |
 | RUNDECK_SKIP_SSL | <ul><li>True</li><li>False (default)</li></ul> | Skip SSL certificate check. |
 | RUNDECK_PROJECTS_EXECUTIONS | <ul><li>True</li><li>False (default)</li></ul> | Get projects executions metrics. |
@@ -196,9 +200,12 @@ Optionally, it's possible to pass the following environment variables to the run
 | RUNDECK_PROJECT_EXECUTIONS_FILTER | Default: 5n | Project executions filter by a period of time. Can be in: **[s]**: seconds, **[n]**: minutes, **[h]**: hour, **[d]**: day, **[w]**: week, **[m]**: month, **[y]**: year. |
 | RUNDECK_PROJECTS_EXECUTIONS_LIMIT | Default: 20 | Projects executions max results per query |
 | RUNDECK_PROJECTS_EXECUTIONS_CACHE | <ul><li>True</li><li>False (default)</li></ul> | Cache requests for project executions metrics query. |
+| RUNDECK_PROJECTS_NODES_INFO | <ul><li>True</li><li>False (default)</li></ul> | Display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available. May cause high CPU load depending on the number of projects. |
 | RUNDECK_CACHED_REQUESTS_TTL | Default: 120 | Rundeck cached requests expiration time. |
-| RUNDECK_CPU_STATS | <ul><li>True</li><li>False (default)</li></ul> | Show Rundeck CPU usage stats |
-| RUNDECK_MEMORY_STATS | <ul><li>True</li><li>False (default)</li></ul> | Show Rundeck memory usage stats |
+| RUNDECK_CPU_STATS | <ul><li>True</li><li>False (default)</li></ul> | Show Rundeck CPU usage stats. |
+| RUNDECK_MEMORY_STATS | <ul><li>True</li><li>False (default)</li></ul> | Show Rundeck memory usage stats. |
+| RUNDECK_EXPORTER_NO_CHECKS_IN_PASSIVE_MODE | <ul><li>True</li><li>False (default)</li></ul> | The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode. |
+| RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS |Default: (number of CPUs) + 4 | The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks. |
 
 ### Example
 

--- a/rundeck_exporter.py
+++ b/rundeck_exporter.py
@@ -68,115 +68,122 @@ class RundeckMetricsCollector(object):
         formatter_class=RawDescriptionHelpFormatter
     )
     args_parser.add_argument('--debug',
-                             help='Enable debug mode.',
+                             help='Enable debug mode',
                              default=getenv('RUNDECK_EXPORTER_DEBUG', False),
                              action='store_true'
                              )
     args_parser.add_argument('-v', '--version',
-                             help='Shows rundeck_exporter current release version.',
+                             help='Shows rundeck_exporter current release version',
                              action='store_true'
                              )
     args_parser.add_argument('--host',
-                             help=f'Host binding address. Default: {default_host}.',
+                             help=f'Host binding address. Default: {default_host}',
                              metavar="RUNDECK_EXPORTER_HOST",
                              default=getenv('RUNDECK_EXPORTER_HOST', default_host)
                              )
     args_parser.add_argument('--port',
-                             help=f'Host binding port. Default: {default_port}.',
+                             help=f'Host binding port. Default: {default_port}',
                              metavar="RUNDECK_EXPORTER_PORT",
                              type=int,
                              default=getenv('RUNDECK_EXPORTER_PORT', default_port)
                              )
     args_parser.add_argument('--no_checks_in_passive_mode',
                              dest='no_checks_in_passive_mode',
-                             help='The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode.',
+                             help='The rundeck_exporter will not perform any checks while the Rundeck host is in passive execution mode',
                              action='store_true',
                              default=getenv('RUNDECK_EXPORTER_NO_CHECKS_IN_PASSIVE_MODE', False)
                              )
     args_parser.add_argument('--threadpool_max_workers',
-                             help='The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks. Defaults to (number of CPUs) + 4.',
+                             help='The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks. Defaults to (number of CPUs) + 4',
                              metavar='RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS',
                              type=int,
                              default=getenv('RUNDECK_EXPORTER_THREADPOOL_MAX_WORKERS', cpu_count() + 4)
                              )
+    args_parser.add_argument('--rundeck.requests.timeout',
+                             dest='rundeck_requests_timeout',
+                             help='The maximum number of seconds that requests to the Rundeck API should timeout',
+                             metavar='RUNDECK_EXPORTER_REQUESTS_TIMEOUT',
+                             type=int,
+                             default=getenv('RUNDECK_EXPORTER_REQUESTS_TIMEOUT', 30)
+                             )
     args_parser.add_argument('--rundeck.url',
                              dest='rundeck_url',
-                             help='Rundeck Base URL [ REQUIRED ].',
+                             help='Rundeck Base URL [ REQUIRED ]',
                              default=getenv('RUNDECK_URL')
                              )
     args_parser.add_argument('--rundeck.skip_ssl',
                              dest='rundeck_skip_ssl',
-                             help='Rundeck Skip SSL Cert Validate.',
+                             help='Rundeck Skip SSL Cert Validate',
                              default=literal_eval(getenv('RUNDECK_SKIP_SSL', 'False').capitalize()),
                              action='store_true'
                              )
     args_parser.add_argument('--rundeck.api.version',
                              dest='rundeck_api_version',
-                             help='Default: 34.',
+                             help='Defaults to 34',
                              type=int,
                              default=getenv('RUNDECK_API_VERSION', 34)
                              )
     args_parser.add_argument('--rundeck.username',
                              dest='rundeck_username',
-                             help='Rundeck User with access to the system information.',
+                             help='Rundeck User with access to the system information',
                              default=getenv('RUNDECK_USERNAME'),
                              required=False
                              )
     args_parser.add_argument('--rundeck.projects.executions',
                              dest='rundeck_projects_executions',
-                             help='Get projects executions metrics.',
+                             help='Get projects executions metrics',
                              default=literal_eval(getenv('RUNDECK_PROJECTS_EXECUTIONS', 'False').capitalize()),
                              action='store_true'
                              )
     args_parser.add_argument('--rundeck.projects.executions.filter',
                              dest='rundeck_project_executions_filter',
                              help='''
-                             Get the latest project executions filtered by time period.
-                             Can be in: [s]: seconds, [n]: minutes, [h]: hour, [d]: day, [w]: week, [m]: month, [y]: year.
-                             Default: 5n.
+                             Get the latest project executions filtered by time period
+                             Can be in: [s]: seconds, [n]: minutes, [h]: hour, [d]: day, [w]: week, [m]: month, [y]: year
+                             Defaults to 5n
                              ''',
                              default=getenv('RUNDECK_PROJECTS_EXECUTIONS_FILTER', '5n')
                              )
     args_parser.add_argument('--rundeck.projects.executions.limit',
                              dest='rundeck_projects_executions_limit',
-                             help='Project executions max results per query. Default: 20.',
+                             help='Project executions max results per query. Defaults to 20',
                              type=int,
                              default=getenv('RUNDECK_PROJECTS_EXECUTIONS_LIMIT', 20)
                              )
     args_parser.add_argument('--rundeck.projects.executions.cache',
                              dest='rundeck_projects_executions_cache',
-                             help='Cache requests for project executions metrics query.',
+                             help='Cache requests for project executions metrics query',
                              default=literal_eval(getenv('RUNDECK_PROJECTS_EXECUTIONS_CACHE', 'False').capitalize()),
                              action='store_true'
                              )
     args_parser.add_argument('--rundeck.projects.filter',
                             dest='rundeck_projects_filter',
-                            help='Get executions only from listed projects (delimiter = space).',
+                            help='Get executions only from listed projects (delimiter = space)',
                             default=getenv('RUNDECK_PROJECTS_FILTER', []),
                             nargs='+',
                             required=False
                             )
     args_parser.add_argument('--rundeck.projects.nodes.info',
                             dest='rundeck_projects_nodes_info',
-                            help='Display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available. May cause high CPU load depending on the number of projects.',
+                            help='Display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available. May cause high CPU load depending on the number of projects',
                             action='store_true',
                             default=getenv('RUNDECK_PROJECTS_NODES_INFO', False)
                             )
     args_parser.add_argument('--rundeck.cached.requests.ttl',
                              dest='rundeck_cached_requests_ttl',
-                             help='Rundeck cached requests expiration time. Default: 120',
+                             help='Rundeck cached requests expiration time. Defaults to 120',
                              type=int,
                              default=getenv('RUNDECK_CACHED_REQUESTS_TTL', 120)
                              )
     args_parser.add_argument('--rundeck.cpu.stats',
                              dest='rundeck_cpu_stats',
-                             help='Show Rundeck CPU usage stats.',
+                             help='Show Rundeck CPU usage stats',
                              action='store_true',
                              default=getenv('RUNDECK_CPU_STATS', False)
                              )
     args_parser.add_argument('--rundeck.memory.stats',
                              dest='rundeck_memory_stats',
-                             help='Show Rundeck memory usage stats.',
+                             help='Show Rundeck memory usage stats',
                              action='store_true',
                              default=getenv('RUNDECK_MEMORY_STATS', False)
                              )
@@ -221,7 +228,7 @@ class RundeckMetricsCollector(object):
 
             if endpoint == '/metrics/metrics' and session.cookies.get_dict().get('JSESSIONID'):
                 request_url = f'{self.args.rundeck_url}{endpoint}'
-                response = session.get(request_url)
+                response = session.get(request_url, timeout=self.args.rundeck_requests_timeout)
                 response_json = json.loads(response.text)
             else:
                 request_url = f'{self.args.rundeck_url}/api/{self.args.rundeck_api_version}{endpoint}'
@@ -231,7 +238,8 @@ class RundeckMetricsCollector(object):
                         'Accept': 'application/json',
                         'X-Rundeck-Auth-Token': self.rundeck_token
                     },
-                    verify=not self.args.rundeck_skip_ssl
+                    verify=not self.args.rundeck_skip_ssl,
+                    timeout=self.args.rundeck_requests_timeout
                 )
                 response_json = response.json()
 


### PR DESCRIPTION
### Added
- Added the following new arguments:
  - `--rundeck.projects.nodes.info` - If passed, display Rundeck projects nodes info metrics, currently only the `rundeck_project_nodes_total` metric is available.
    - Requests for this check are cached as it can cause high CPU load depending on the number of projects.
  - `--threadpool_max_workers` - The maximum number of workers in the threadpool to run rundeck_exporter asynchronous checks.
    - Defaults to `(number of CPUs) + 4`, which may be too much on a server running other services.
  - `--rundeck.requests.timeout` - The maximum number of seconds that requests to the Rundeck API should timeout.
    - Defaults to 30.

### Changed
- Changed the functions `request_data_from` and `cached_request_data_from` to `request` and `cached_request`, respectively.