### PR TITLE
chore: add uv.lock version bump to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,14 @@
   "include-component-in-tag": false,
   "packages": {
     ".": {
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='rundeck-exporter')].version"
+        }
+      ]
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
         {
           "path": "uv.lock",
           "type": "toml",
-          "jsonpath": "$.package[?(@.name.value=='rundeck-exporter')].version"
+          "jsonpath": "$.package[?(@.name=='rundeck-exporter')].version"
         }
       ]
     }


### PR DESCRIPTION
Workaround to make release-please update uv.lock version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Python release configuration to include additional build artifact tracking, ensuring changelog entries also reflect the `rundeck-exporter` version from the lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->