### PR TITLE
fix(ci): use PAT for release-please and add workflow_dispatch to release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - v*
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v4.0.0)'
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ github.ref_name }}
@@ -12,7 +17,7 @@ concurrency:
 
 env:
   IMAGE_NAME: rundeck-exporter
-  GIT_TAG: "${{ github.ref_name }}"
+  GIT_TAG: "${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
   GH_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
 
 jobs:
@@ -20,6 +25,13 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Validate release tag format
+        run: |
+          if [[ ! "$GIT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Expected tag format vX.Y.Z (optionally pre-release), got: $GIT_TAG" >&2
+            exit 1
+          fi
+
       - id: get-version
         name: Get version from tag
         run: |


### PR DESCRIPTION
## Summary

- **`release-please.yml`**: Switch from `GITHUB_TOKEN` to `GH_RELEASE_TOKEN` (PAT). Tags pushed via `GITHUB_TOKEN` are intentionally blocked from triggering downstream workflows by GitHub — this was silently skipping the release pipeline (confirmed: no run exists for v4.0.0).
- **`release.yml`**: Add `workflow_dispatch` trigger so the release pipeline can be manually re-triggered from the Actions UI for any tag (useful for v4.0.0 which was skipped).

## Test plan

- [ ] Merge this PR
- [ ] Trigger **Actions → Release → Run workflow**, select tag `v4.0.0` — verify Docker, GHCR, and PyPI publish steps run
- [ ] On next release-please merge, confirm the release pipeline fires automatically on the new tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release automation to use the dedicated release token for creating/updating releases and related pull requests.
  * Enhanced the release workflow to run manually, allowing an explicit release tag input with validation before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->